### PR TITLE
Updates eframe and other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,19 +19,18 @@ clap = { version = "=3.0.0", default-features = false, features = [
 clap_derive = { version = "=3.0.0" }
 uuid = { version = "0.8.2", features = ["v4"] }
 cansi = "2.1.1"
-eframe = { version = "0.16.0", default-features = false, features = [
+eframe = { version = "0.18.0", default-features = false, features = [
     "default_fonts",
-    "egui_glium",
 ] }
-linkify = "0.8.0"
-thiserror = "1.0.30"
+linkify = "0.8.1"
+thiserror = "1.0.31"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-native-dialog = "0.6.2"
+native-dialog = "0.6.3"
 
 # Should make dialogs look better
 [target.'cfg(target_os = "windows")'.dependencies]
-native-dialog = { version = "0.6.2", features = [
+native-dialog = { version = "0.6.3", features = [
     "windows_dpi_awareness",
     "windows_visual_styles",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,10 @@ mod settings;
 use app_state::AppState;
 use child_app::{ChildApp, StdinType};
 use clap::{App, ArgMatches, FromArgMatches, IntoApp};
-use eframe::{Frame, egui::{self, Button, Color32, Context, FontData, FontDefinitions, Grid, Style, TextEdit, Ui}, CreationContext};
+use eframe::{
+    egui::{self, Button, Color32, Context, FontData, FontDefinitions, Grid, Style, TextEdit, Ui},
+    CreationContext, Frame,
+};
 use error::ExecutionError;
 use native_dialog::FileDialog;
 
@@ -92,10 +95,14 @@ pub fn run_app(app: App<'static>, settings: Settings, f: impl FnOnce(&ArgMatches
             style: settings.style,
         };
         let native_options = eframe::NativeOptions::default();
-        eframe::run_native(app_name.as_str(), native_options, Box::new(|cc| {
-            klask.setup(cc);
-            Box::new(klask)
-        }));
+        eframe::run_native(
+            app_name.as_str(),
+            native_options,
+            Box::new(|cc| {
+                klask.setup(cc);
+                Box::new(klask)
+            }),
+        );
     }
 }
 
@@ -281,7 +288,7 @@ impl Klask<'_> {
                 FontData {
                     font: custom_font,
                     index: 0,
-                    tweak: Default::default()
+                    tweak: Default::default(),
                 },
             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,7 @@ mod settings;
 use app_state::AppState;
 use child_app::{ChildApp, StdinType};
 use clap::{App, ArgMatches, FromArgMatches, IntoApp};
-use eframe::{
-    egui::{self, Button, Color32, CtxRef, FontData, FontDefinitions, Grid, Style, TextEdit, Ui},
-    epi,
-};
+use eframe::{Frame, egui::{self, Button, Color32, Context, FontData, FontDefinitions, Grid, Style, TextEdit, Ui}, CreationContext};
 use error::ExecutionError;
 use native_dialog::FileDialog;
 
@@ -71,13 +68,14 @@ pub fn run_app(app: App<'static>, settings: Settings, f: impl FnOnce(&ArgMatches
     } else {
         // During validation we don't pass in a binary name
         let app = app.setting(clap::AppSettings::NoBinaryName);
+        let app_name = app.get_name().to_string();
 
         // eframe::run_native requires that Box::new(klask) has 'static
         // lifetime, so we must leak here. But it never returns (return value !)
         // so it should be ok.
         let localization = Box::leak(Box::new(settings.localization));
 
-        let klask = Klask {
+        let mut klask = Klask {
             state: AppState::new(&app, localization),
             tab: Tab::Arguments,
             env: settings.enable_env.map(|desc| (desc, vec![])),
@@ -94,7 +92,10 @@ pub fn run_app(app: App<'static>, settings: Settings, f: impl FnOnce(&ArgMatches
             style: settings.style,
         };
         let native_options = eframe::NativeOptions::default();
-        eframe::run_native(Box::new(klask), native_options);
+        eframe::run_native(app_name.as_str(), native_options, Box::new(|cc| {
+            klask.setup(cc);
+            Box::new(klask)
+        }));
     }
 }
 
@@ -152,12 +153,8 @@ enum Tab {
     Stdin,
 }
 
-impl epi::App for Klask<'_> {
-    fn name(&self) -> &str {
-        self.app.get_name()
-    }
-
-    fn update(&mut self, ctx: &CtxRef, _frame: &epi::Frame) {
+impl eframe::App for Klask<'_> {
+    fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 // Tab selection
@@ -269,9 +266,11 @@ impl epi::App for Klask<'_> {
             });
         });
     }
+}
 
-    fn setup(&mut self, ctx: &CtxRef, _: &epi::Frame, _: Option<&dyn epi::Storage>) {
-        ctx.set_style(self.style.clone());
+impl Klask<'_> {
+    fn setup(&mut self, cc: &CreationContext) {
+        cc.egui_ctx.set_style(self.style.clone());
 
         if let Some(custom_font) = self.custom_font.take() {
             let font_name = String::from("custom_font");
@@ -282,27 +281,26 @@ impl epi::App for Klask<'_> {
                 FontData {
                     font: custom_font,
                     index: 0,
+                    tweak: Default::default()
                 },
             );
 
             fonts
-                .fonts_for_family
+                .families
                 .entry(egui::FontFamily::Proportional)
                 .or_default()
                 .insert(0, font_name.clone());
 
             fonts
-                .fonts_for_family
+                .families
                 .entry(egui::FontFamily::Monospace)
                 .or_default()
                 .push(font_name);
 
-            ctx.set_fonts(fonts);
+            cc.egui_ctx.set_fonts(fonts);
         }
     }
-}
 
-impl Klask<'_> {
     fn try_start_execution(&mut self) -> Result<ChildApp, ExecutionError> {
         let args = self.state.get_cmd_args(vec![])?;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -177,9 +177,7 @@ impl OutputType {
             // Add a newline here for copying out text
             Some(Self::PROGRESS_BAR_STR) => Some(Self::ProgressBar(
                 format!("{}\n", iter.next().unwrap_or_default()),
-                iter.next()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or_default(),
+                iter.next().and_then(|s| s.parse().ok()).unwrap_or_default(),
             )),
             None => None,
             _ => panic!(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -178,8 +178,7 @@ impl OutputType {
             Some(Self::PROGRESS_BAR_STR) => Some(Self::ProgressBar(
                 format!("{}\n", iter.next().unwrap_or_default()),
                 iter.next()
-                    .map(|s| s.parse().ok())
-                    .flatten()
+                    .and_then(|s| s.parse().ok())
                     .unwrap_or_default(),
             )),
             None => None,


### PR DESCRIPTION
Thanks for this awesome library :wink:. This pull request updates `eframe` and other dependencies to their latest version.

It ignores `clap` and `uuid` as those are already updated in [this pull request](https://github.com/MichalGniadek/klask/pull/36). Note that I also created a pull request for that pull request which solves the unicode problem and that you may merge directly.