### PR TITLE
Remove panic when parsing

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -179,8 +179,7 @@ impl OutputType {
                 format!("{}\n", iter.next().unwrap_or_default()),
                 iter.next().and_then(|s| s.parse().ok()).unwrap_or_default(),
             )),
-            None => None,
-            _ => panic!(),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
It's probably going to show garbage in the output, but at least it won't crash if you're expecting some side effect like generating a file.