### PR TITLE
Request repaint on stdout/stderr changes

### DIFF
--- a/src/child_app.rs
+++ b/src/child_app.rs
@@ -1,4 +1,4 @@
-use crate::{ExecutionError, CHILD_APP_ENV_VAR};
+use crate::{ExecutionError, CHILD_APP_ENV_VAR, CTX};
 use std::{
     fs::File,
     io::{BufRead, BufReader, Read, Write},
@@ -109,6 +109,11 @@ impl ChildApp {
                 // End of output
                 let _ = tx.send(None);
                 break;
+            }
+            unsafe {
+                if let Some(ctx) = &CTX {
+                    ctx.request_repaint();
+                }
             }
             // Send returns error only if data will never be received
             if tx.send(Some(output)).is_err() {

--- a/src/child_app.rs
+++ b/src/child_app.rs
@@ -1,4 +1,4 @@
-use crate::{ExecutionError, CHILD_APP_ENV_VAR, CTX};
+use crate::{ExecutionError, CHILD_APP_ENV_VAR};
 use std::{
     fs::File,
     io::{BufRead, BufReader, Read, Write},
@@ -109,11 +109,6 @@ impl ChildApp {
                 // End of output
                 let _ = tx.send(None);
                 break;
-            }
-            unsafe {
-                if let Some(ctx) = &CTX {
-                    ctx.request_repaint();
-                }
             }
             // Send returns error only if data will never be received
             if tx.send(Some(output)).is_err() {

--- a/src/child_app.rs
+++ b/src/child_app.rs
@@ -1,4 +1,5 @@
 use crate::{ExecutionError, CHILD_APP_ENV_VAR};
+use eframe::egui;
 use std::{
     fs::File,
     io::{BufRead, BufReader, Read, Write},
@@ -27,6 +28,7 @@ impl ChildApp {
         env: Option<Vec<(String, String)>>,
         stdin: Option<StdinType>,
         working_dir: Option<String>,
+        ctx: egui::Context,
     ) -> Result<Self, ExecutionError> {
         let mut child = Command::new(std::env::current_exe()?);
 
@@ -54,6 +56,7 @@ impl ChildApp {
                 .stdout
                 .take()
                 .ok_or(ExecutionError::NoStdoutOrStderr)?,
+            ctx.clone(),
         );
 
         let stderr = Self::spawn_thread_reader(
@@ -61,6 +64,7 @@ impl ChildApp {
                 .stderr
                 .take()
                 .ok_or(ExecutionError::NoStdoutOrStderr)?,
+            ctx,
         );
 
         if let Some(stdin) = stdin {
@@ -100,7 +104,10 @@ impl ChildApp {
         self.stderr = None;
     }
 
-    fn spawn_thread_reader<R: Read + Send + Sync + 'static>(stdio: R) -> Receiver<Option<String>> {
+    fn spawn_thread_reader<R: Read + Send + Sync + 'static>(
+        stdio: R,
+        ctx: egui::Context,
+    ) -> Receiver<Option<String>> {
         let mut reader = BufReader::new(stdio);
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || loop {
@@ -108,12 +115,14 @@ impl ChildApp {
             if let Ok(0) = reader.read_line(&mut output) {
                 // End of output
                 let _ = tx.send(None);
+                ctx.request_repaint();
                 break;
             }
             // Send returns error only if data will never be received
             if tx.send(Some(output)).is_err() {
                 break;
             }
+            ctx.request_repaint();
         });
         rx
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@ struct Klask<'s> {
     style: Style,
 }
 
+static mut CTX: Option<egui::Context> = None;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum Tab {
     Arguments,
@@ -275,6 +277,10 @@ impl eframe::App for Klask<'_> {
 
 impl Klask<'_> {
     fn setup(&mut self, cc: &CreationContext) {
+        let ctx = cc.egui_ctx.clone();
+        unsafe {
+            let _ = CTX.insert(ctx);
+        }
         cc.egui_ctx.set_style(self.style.clone());
 
         if let Some(custom_font) = self.custom_font.take() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,6 @@ struct Klask<'s> {
     style: Style,
 }
 
-static mut CTX: Option<egui::Context> = None;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum Tab {
     Arguments,
@@ -277,10 +275,6 @@ impl eframe::App for Klask<'_> {
 
 impl Klask<'_> {
     fn setup(&mut self, cc: &CreationContext) {
-        let ctx = cc.egui_ctx.clone();
-        unsafe {
-            let _ = CTX.insert(ctx);
-        }
         cc.egui_ctx.set_style(self.style.clone());
 
         if let Some(custom_font) = self.custom_font.take() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl eframe::App for Klask<'_> {
                         )
                         .clicked()
                     {
-                        match self.try_start_execution() {
+                        match self.try_start_execution(ctx.clone()) {
                             Ok(child) => {
                                 // Reset
                                 self.state.update_validation_error("", "");
@@ -306,7 +306,7 @@ impl Klask<'_> {
         }
     }
 
-    fn try_start_execution(&mut self) -> Result<ChildApp, ExecutionError> {
+    fn try_start_execution(&mut self, ctx: egui::Context) -> Result<ChildApp, ExecutionError> {
         let args = self.state.get_cmd_args(vec![])?;
 
         // Check for validation errors
@@ -330,6 +330,7 @@ impl Klask<'_> {
             self.env.clone().map(|(_, env)| env),
             self.stdin.clone().map(|(_, stdin)| stdin),
             self.working_dir.clone().map(|(_, dir)| dir),
+            ctx,
         )
     }
 


### PR DESCRIPTION
Proof-of-concept fix for #51, using an unsafe `static mut CTX` to save the `egui::Context`.

Doing this right could be done by adding a `ctx` field to the `Klask` type, however, this may be a big conceptual change? Also, `egui::Context` does not `impl std::fmt::Debug`, so it breaks the `#[derive(Debug)]` on `Klask`.

Let me know what you think when you have the time :)