### PR TITLE
Set initial value of multiple values list to default value (if available)

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -39,7 +39,7 @@ pub enum Subcommand {
 #[derive(Debug, Parser)]
 pub enum InnerSubcommand {
     InnerSubcommandA {
-        #[clap(short, multiple_occurrences(true))]
+        #[clap(short, multiple_occurrences(true), default_value = "initial value")]
         multiple_values: Vec<String>,
     },
     /// About

--- a/src/arg_state.rs
+++ b/src/arg_state.rs
@@ -48,6 +48,8 @@ impl<'s> ArgState<'s> {
                 .iter()
                 .map(|s| s.to_string_lossy().into_owned());
 
+            let initial_values = default.clone().map(|s| (s, Uuid::new_v4())).collect();
+
             let possible = arg
                 .get_possible_values()
                 .unwrap_or_default()
@@ -60,7 +62,7 @@ impl<'s> ArgState<'s> {
 
             if multiple_occurrences | multiple_values {
                 ArgKind::MultipleStrings {
-                    values: vec![],
+                    values: initial_values,
                     default: default.collect(),
                     possible,
                     multiple_values,


### PR DESCRIPTION
Hi :)

I noticed that currently, if a `multiple_values` field has a default value, this value does not appear initially in the list of arguments (which initially is empty). But when clicking the "Reset to default" button, the default value is entered as the first entry in the `multiple_values` sequence.

This change pre-populates the `multiple_values` vector with the default value, if one is given. On "Reset to default", this state is restored. The default value can also still be edited and removed with the `-` button.

Let me know what you think :)