### PR TITLE
Updates, wasm32 and public modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "3", default-features = false, features = [
     "unicode",
 ] }
 eframe = { version = "0.20.0", default-features = false, features = [
-    "default_fonts",
+    "default_fonts", "glow",
 ] }
 heck = { version = "*", features = ["unicode"] } # Add unicode support to clap
 linkify = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,14 @@ clap = { version = "3", default-features = false, features = [
     "derive",
     "unicode",
 ] }
-heck = { version = "*", features = ["unicode"] } # Add unicode support to clap
-uuid = { version = "1.0.0", features = ["v4"] }
+clap_derive = { version = "=3.0.0" }
+uuid = { version = "1.3", features = ["v4"] }
 cansi = "2.1.1"
-eframe = { version = "0.16.0", default-features = false, features = [
-    "default_fonts",
-    "egui_glium",
+eframe = { version = "0.21", default-features = false, features = [
+    "default_fonts", "glow"
 ] }
-linkify = "0.8.0"
-thiserror = "1.0.30"
+linkify = "0.9"
+thiserror = "1.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 native-dialog = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3", default-features = false, features = [
 ] }
 clap_derive = { version = "=3.0.0" }
 uuid = { version = "1.3", features = ["v4"] }
-cansi = "2.1.1"
 eframe = { version = "0.21", default-features = false, features = [
     "default_fonts", "glow"
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "3", default-features = false, features = [
     "derive",
     "unicode",
 ] }
-eframe = { version = "0.18.0", default-features = false, features = [
+eframe = { version = "0.20.0", default-features = false, features = [
     "default_fonts",
 ] }
 heck = { version = "*", features = ["unicode"] } # Add unicode support to clap

--- a/src/arg_state.rs
+++ b/src/arg_state.rs
@@ -2,6 +2,7 @@ use crate::{settings::Localization, Klask};
 use clap::{Arg, ValueHint};
 use eframe::egui::{widgets::Widget, ComboBox, Response, TextEdit, Ui};
 use inflector::Inflector;
+#[cfg(not(target_arch = "wasm32"))]
 use rfd::FileDialog;
 use uuid::Uuid;
 
@@ -130,6 +131,7 @@ impl<'s> ArgState<'s> {
                     ValueHint::AnyPath | ValueHint::FilePath | ValueHint::ExecutablePath
                 ) && ui.button(&localization.select_file).clicked()
                 {
+                    #[cfg(not(target_arch = "wasm32"))]
                     if let Some(file) = FileDialog::new().pick_file() {
                         *value = file.to_string_lossy().into_owned();
                     }
@@ -138,6 +140,7 @@ impl<'s> ArgState<'s> {
                 if matches!(value_hint, ValueHint::AnyPath | ValueHint::DirPath)
                     && ui.button(&localization.select_directory).clicked()
                 {
+                    #[cfg(not(target_arch = "wasm32"))]
                     if let Some(file) = FileDialog::new().pick_folder() {
                         *value = file.to_string_lossy().into_owned();
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use eframe::{
     CreationContext, Frame,
 };
 use error::ExecutionError;
+#[cfg(not(target_arch = "wasm32"))]
 use rfd::FileDialog;
 
 use output::Output;
@@ -59,6 +60,7 @@ const CHILD_APP_ENV_VAR: &str = "KLASK_CHILD_APP";
 ///    println!("{}", matches.is_present("debug"))
 /// });
 /// ```
+#[cfg(not(target_arch = "wasm32"))]
 pub fn run_app(app: Command<'static>, settings: Settings, f: impl FnOnce(&ArgMatches)) {
     if std::env::var(CHILD_APP_ENV_VAR).is_ok() {
         std::env::remove_var(CHILD_APP_ENV_VAR);
@@ -213,6 +215,7 @@ impl eframe::App for Klask<'_> {
                             let localization = self.localization;
                             ui.horizontal(|ui| {
                                 if ui.button(&localization.select_directory).clicked() {
+                                    #[cfg(not(target_arch = "wasm32"))]
                                     if let Some(file) = FileDialog::new().pick_folder() {
                                         *path = file.to_string_lossy().into_owned();
                                     }
@@ -431,6 +434,7 @@ impl Klask<'_> {
             StdinType::File(path) => {
                 ui.horizontal(|ui| {
                     if ui.button(&localization.select_file).clicked() {
+                        #[cfg(not(target_arch = "wasm32"))]
                         if let Some(file) = FileDialog::new().pick_file() {
                             *path = file.to_string_lossy().into_owned();
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ impl epi::App for Klask<'_> {
 
                     if self.is_child_running() {
                         let mut running_text = String::from(&self.localization.running);
-                        for _ in 0..((2.0 * ui.input().time) as i32 % 4) {
+                        for _ in 0..((2.0 * ui.input(|i| i.time)) as i32 % 4) {
                             running_text.push('.')
                         }
                         ui.label(running_text);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub fn run_app(app: Command<'static>, settings: Settings, f: impl FnOnce(&ArgMat
 ///     println!("{}", example.debug);
 /// });
 /// ```
+#[cfg(not(target_arch = "wasm32"))]
 pub fn run_derived<C, F>(settings: Settings, f: F)
 where
     C: IntoApp + FromArgMatches,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,13 @@
 //! }
 //! ```
 
-mod app_state;
+pub mod app_state;
 mod arg_state;
 mod child_app;
 mod error;
 /// Additional options for output like progress bars.
 pub mod output;
-mod settings;
+pub mod settings;
 
 use app_state::AppState;
 use child_app::{ChildApp, StdinType};

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,11 +1,13 @@
-use crate::child_app::ChildApp;
-use crate::error::ExecutionError;
-use cansi::{CategorisedSlice, Color};
-use eframe::egui::{vec2, Color32, Label, ProgressBar, RichText, Ui, Widget};
-use linkify::{LinkFinder, LinkKind};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
+
+use cansi::{CategorisedSlice, Color};
+use eframe::egui::{Color32, Label, ProgressBar, RichText, Ui, vec2, Widget};
+use linkify::{LinkFinder, LinkKind};
+
+use crate::child_app::ChildApp;
+use crate::error::ExecutionError;
 
 /// Displays a progress bar in the output. First call creates
 /// a progress bar and future calls update it.
@@ -107,15 +109,16 @@ impl Widget for &mut Output {
                 // View
                 ui.vertical(|ui| {
                     if ui.button("Copy output").clicked() {
-                        ui.ctx().output().copied_text = output
-                            .iter()
-                            .map(|(_, o)| match o {
-                                OutputType::Text(text) => text,
-                                OutputType::ProgressBar(text, _) => text,
-                            })
-                            .flat_map(|text| cansi::categorise_text(text))
-                            .map(|slice| slice.text)
-                            .collect::<String>();
+                        ui.ctx().output_mut(|p|
+                            p.copied_text = output
+                                .iter()
+                                .map(|(_, o)| match o {
+                                    OutputType::Text(text) => text,
+                                    OutputType::ProgressBar(text, _) => text,
+                                })
+                                .flat_map(|text| cansi::categorise_text(text))
+                                .map(|slice| slice.text)
+                                .collect::<String>());
                     }
 
                     for (_, o) in output {
@@ -132,7 +135,7 @@ impl Widget for &mut Output {
                         }
                     }
                 })
-                .response
+                    .response
             }
         }
     }
@@ -172,7 +175,7 @@ impl OutputType {
         }
     }
 
-    pub fn parse<'a>(iter: &mut impl Iterator<Item = &'a str>) -> Option<Self> {
+    pub fn parse<'a>(iter: &mut impl Iterator<Item=&'a str>) -> Option<Self> {
         match iter.next() {
             // Add a newline here for copying out text
             Some(Self::PROGRESS_BAR_STR) => Some(Self::ProgressBar(


### PR DESCRIPTION
Hey, this pull request updates eframe and fixes compilation on wasm32.

It also publishes the internal modules app_state and settings, so that this app can be embedded into another egui app. Take a look at [this demo](https://yeicor.github.io/sdf-viewer/?envdark) of using klask to update configuration at runtime (top-left buttons) to see why this is useful.

Sadly, this last contribution increases the size of the public API, and you may not want to maintain a bigger API. If this is the case, I'll maintain the fork for my projects.