### PR TITLE
Fix usage of deprecated clap features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "3", default-features = false, features = [
     "std",
     "derive",
     "unicode",
+    "deprecated",
 ] }
 eframe = { version = "0.18.0", default-features = false, features = [
     "default_fonts",

--- a/examples/validation.rs
+++ b/examples/validation.rs
@@ -1,0 +1,23 @@
+//! Value validation
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+use clap::Parser;
+use klask::Settings;
+
+#[derive(Debug, Parser)]
+#[clap(name = "Validation Example")]
+/// Help is displayed at the top
+pub struct Validation {
+    #[clap(long, value_parser(is_hello))]
+    input: String,
+}
+
+fn is_hello(input: &str) -> Result<String, String> {
+    match input {
+        "hello" => Ok(input.to_string()),
+        _ => Err("Is not \"hello\"".to_string()),
+    }
+}
+
+fn main() {
+    klask::run_derived::<Validation, _>(Settings::default(), |o| println!("{:#?}", o));
+}

--- a/src/arg_state.rs
+++ b/src/arg_state.rs
@@ -49,9 +49,10 @@ impl<'s> ArgState<'s> {
                 .map(|s| s.to_string_lossy().into_owned());
 
             let possible = arg
-                .get_possible_values()
-                .unwrap_or_default()
-                .iter()
+                .get_value_parser()
+                .possible_values()
+                .unwrap_or(Box::new(std::iter::empty()))
+                .into_iter()
                 .map(|v| v.get_name().to_string())
                 .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub fn run_app(app: Command<'static>, settings: Settings, f: impl FnOnce(&ArgMat
         f(&matches);
     } else {
         // During validation we don't pass in a binary name
-        let app = app.setting(clap::AppSettings::NoBinaryName);
+        let app = app.no_binary_name(true);
         let app_name = app.get_name().to_string();
 
         // eframe::run_native requires that Box::new(klask) has 'static


### PR DESCRIPTION
I figured whether or not this gets ported to clap 4, it would make sense to not rely on now deprecated clap 3 features. This is my initial attempt, I still need to figure out how to handle `arg.is_multiple_occurrences_set` and `arg.is_forbid_empty_values_set`.