### PR TITLE
Fix #54: Handle positional bool flags correctly

### DIFF
--- a/src/app_state/tests.rs
+++ b/src/app_state/tests.rs
@@ -191,6 +191,17 @@ fn different_multiple_values() {
     )
 }
 
+#[derive(Debug, Parser, PartialEq, Eq)]
+struct PositionalBool {
+    verbose: bool,
+}
+
+#[test]
+fn positional_bool() {
+    test_app(|_| {}, PositionalBool { verbose: false });
+    test_app(|args| args[0].set(), PositionalBool { verbose: true })
+}
+
 fn test_app<C, F>(setup: F, expected: C)
 where
     C: IntoApp + FromArgMatches + Debug + Eq,

--- a/src/arg_state.rs
+++ b/src/arg_state.rs
@@ -274,11 +274,7 @@ impl<'s> ArgState<'s> {
             }
             &ArgKind::Bool(bool) => {
                 if bool {
-                    args.push(
-                        self.call_name
-                            .clone()
-                            .ok_or_else(|| "Internal error.".to_string())?,
-                    );
+                    args.push(self.call_name.clone().unwrap_or_else(|| "true".to_owned()));
                 }
             }
         }


### PR DESCRIPTION
Basically, I just pass "true" as the arg instead of throwing an error. I've tried a few combinations of the args, each with a bool that is not annotated with `#[clap(short, long)]` and it seems to work fine.